### PR TITLE
running with `sudo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ AWS compatible OpenVPN v2.4.9, based on the
 1. Build patched openvpn version and put it to the folder with a script
 2. Build aws-vpn-client wrapper `go build .`
 3. `cp ./awsvpnclient.yml.example ./awsvpnclient.yml` and update the necsery paths.
-4. Finally run `./aws-vpn-client serve --config myconfig.openvpn` to connect to the AWS.
+4. Finally run `./aws-vpn-client serve --config myconfig.openvpn` to connect to the AWS, or run it under root privilege, `sudo ./aws-vpn-client serve --config myconfig.openvpn`
 
 ## Todo
 

--- a/utils.go
+++ b/utils.go
@@ -10,12 +10,20 @@ import (
 	"path"
 	"runtime"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 )
 
 func openDefaultBrowser(url string) (err error) {
 	switch runtime.GOOS {
 	case "linux":
-		err = exec.Command("xdg-open", url).Start()
+		user := os.Getenv("SUDO_USER")
+		if (user == "") {
+			err = exec.Command("xdg-open", url).Start()
+		} else {
+			log.Info().Msg("open browser as " + user)
+			err = exec.Command("sudo", "-u", user, "xdg-open", url).Start()
+		}
 	case "windows":
 		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
 	case "darwin":


### PR DESCRIPTION
openvpn requires root privilege, but open auth url usually requires as current user. Currently it prompts for sudo credential in the middle of steps, which is not very convenient. Now user can run aws-vpn-client with sudo, and it opens url as current user.