### PR TITLE
Feat: Open browsers as non-root level permissions.

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,6 +12,7 @@ type (
 		Sudo      string
 		Shell     string
 		ShellArgs []string
+		User      string
 	}
 
 	server struct {

--- a/serve.go
+++ b/serve.go
@@ -150,7 +150,7 @@ func startOpenVPNConnection(handle *serveHandle) {
 	log.Info().Msgf("open to authenticate into OpenVPN tunnel: %s", authUrl)
 
 	if handle.Config.Browser {
-		openDefaultBrowser(authUrl)
+		openDefaultBrowser(handle.Config.Vpn.User, authUrl)
 	}
 
 	log.Info().Msg("Waiting for SAML response from 3rd party service...")
@@ -183,7 +183,9 @@ func startOpenVPNConnection(handle *serveHandle) {
 		"--auth-user-pass", tmpAuthConifg,
 	)
 
-	if handle.Config.Vpn.Shell == "" {
+	// If the user didn't provide a shell or we are already running as root.
+	// Non special hacks are needed to to run this step.
+	if handle.Config.Vpn.Shell == "" || isRoot() {
 		baseCommand.Env = os.Environ()
 		baseCommand.Stdout = os.Stdout
 		baseCommand.Stderr = os.Stderr


### PR DESCRIPTION
Adds Env and SysProcAttr injection when root level permissions are detected when attempting to open the browser and will skip using shell when attempting to root when connecting to the vpn service.

### Example

awsvpnclient.yaml
```
browser: true
vpn:
  openvpn: /home/user/path/to/openvpn_aws
server:
  addr: "127.0.0.1:35001"

```

```sh
sudo unix-aws-vpn-client start -c sso-openvpn-server.ovpn
```

Will open browser as non-root permission.

Added `user` field in vpn that will act as a fallback if `SUDO_USER` env isn't used.