### PR TITLE
Feat: Added landing pages for server

### DIFF
--- a/html/error.html
+++ b/html/error.html
@@ -1,0 +1,33 @@
+<!-- index.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Unix AWS VPN Client - Woops!</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            text-align: center;
+            padding: 50px;
+            background-color: #f7f7f7;
+        }
+        h1 {
+            color: #b33737;
+        }
+        a {
+            color: #2b9cd0;
+            text-decoration: none;
+            font-size: 1.2em;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <h1>Something went wrong!</h1>
+    <p>Seems like something unexpected happened with SSO redirect! Please look at the terminal output for any errors!</p>
+    <p>Think it's a bug with unix aws vpn client? <a href="https://github.com/ajm113/unix-aws-vpn-client/issues" target="_blank">Report it!</a></p>
+</body>
+</html>

--- a/html/index.html
+++ b/html/index.html
@@ -1,0 +1,33 @@
+<!-- index.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Unix AWS VPN Client</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            text-align: center;
+            padding: 50px;
+            background-color: #f7f7f7;
+        }
+        h1 {
+            color: #37b33b;
+        }
+        a {
+            color: #2b9cd0;
+            text-decoration: none;
+            font-size: 1.2em;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <h1>Connection Established!</h1>
+    <p>Your connection to the VPN tunnel is now active.</p>
+    <a href="#" onclick="window.close()">Click here to close this window</a>
+</body>
+</html>


### PR DESCRIPTION
Adds HTML landing pages to SAML listen server to make it user friendly when we reached a happy or unhappy path. Also logs warn if open browser reports an issue.

![image](https://github.com/user-attachments/assets/aa19e36a-79ae-48bb-90a3-c230b61475b4)

Small html files are embedded into the binary so managing em should be completely agnostic to the end user.

